### PR TITLE
Add PWA interface

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import os
 import json
 from selenium.webdriver.common.by import By
 from selenium.common.exceptions import NoSuchElementException
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, request, send_from_directory, render_template
 from flask_cors import CORS
 from wallet_entries import extract_wallet_entries
 from utils import setup_driver, extract_table_header, extract_table_data
@@ -13,10 +13,22 @@ from datetime import datetime, date
 
 sys.stdout.reconfigure(line_buffering=True)
 
-app = Flask(__name__)
+app = Flask(__name__, static_folder='static', template_folder='templates', static_url_path='/static')
 CORS(app, resources={r"/*": {"origins": [
     "http://localhost:8080", "https://localhost:8080"
 ]}})
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+@app.route("/manifest.json")
+def manifest():
+    return send_from_directory(app.root_path, 'manifest.json')
+
+@app.route("/service-worker.js")
+def service_worker():
+    return send_from_directory(app.root_path, 'service-worker.js')
 
 def extract_assets_data(driver, url):
     collapsed_tables = []

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "Investidor10 PWA",
+  "short_name": "Investidor10",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": []
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,19 @@
+const CACHE_NAME = 'investidor10-cache-v1';
+const urlsToCache = [
+  '/',
+  '/static/style.css',
+  '/static/app.js',
+  '/manifest.json'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(urlsToCache))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,35 @@
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/service-worker.js');
+    });
+}
+
+async function callApi(endpoint, params) {
+    const loader = document.getElementById('loader');
+    const output = document.getElementById('output');
+    loader.classList.remove('hidden');
+    output.textContent = '';
+    try {
+        const url = new URL(endpoint, window.location.origin);
+        Object.keys(params).forEach(k => url.searchParams.append(k, params[k]));
+        const response = await fetch(url);
+        const text = await response.text();
+        output.textContent = text;
+    } catch (e) {
+        output.textContent = 'Erro: ' + e;
+    } finally {
+        loader.classList.add('hidden');
+    }
+}
+
+document.getElementById('assetsBtn').addEventListener('click', () => {
+    callApi('/assets', {wallet_url: document.getElementById('walletUrl').value});
+});
+
+document.getElementById('entriesBtn').addEventListener('click', () => {
+    callApi('/wallet-entries', {wallet_entries_url: document.getElementById('walletEntriesUrl').value});
+});
+
+document.getElementById('dataComBtn').addEventListener('click', () => {
+    callApi('/data-com', {wallet_url: document.getElementById('walletUrl').value});
+});

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,46 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: #f2f2f2;
+}
+.container {
+    max-width: 600px;
+    margin: auto;
+    padding: 1rem;
+}
+.form-group {
+    margin-bottom: 1rem;
+    display: flex;
+    flex-direction: column;
+}
+.buttons {
+    display: flex;
+    gap: .5rem;
+}
+button {
+    flex: 1;
+    padding: .5rem;
+}
+#output {
+    background: #fff;
+    padding: 1rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+.loader {
+    border: 4px solid #f3f3f3;
+    border-top: 4px solid #444;
+    border-radius: 50%;
+    width: 30px;
+    height: 30px;
+    animation: spin 1s linear infinite;
+    margin: 1rem auto;
+}
+.hidden {
+    display: none;
+}
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Investidor10 PWA</title>
+    <link rel="manifest" href="/manifest.json">
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Investidor10 API</h1>
+        <div class="form-group">
+            <label for="walletUrl">Wallet URL:</label>
+            <input id="walletUrl" type="text" placeholder="https://.../wallet" />
+        </div>
+        <div class="form-group">
+            <label for="walletEntriesUrl">Wallet Entries URL:</label>
+            <input id="walletEntriesUrl" type="text" placeholder="https://.../wallet-entries" />
+        </div>
+        <div class="buttons">
+            <button id="assetsBtn">Assets</button>
+            <button id="entriesBtn">Entries</button>
+            <button id="dataComBtn">Data Com</button>
+        </div>
+        <div id="loader" class="loader hidden"></div>
+        <pre id="output"></pre>
+    </div>
+    <script src="/static/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple PWA front-end with manifest and service worker
- serve front-end from Flask app
- provide responsive HTML form to call existing endpoints

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile *.py`
- `python main.py & sleep 5; pkill -f main.py`

------
https://chatgpt.com/codex/tasks/task_e_687328040858832c85f27d3dc403394a