### PR TITLE
Add simple web interface

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import os
 import json
 from selenium.webdriver.common.by import By
 from selenium.common.exceptions import NoSuchElementException
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, request, render_template
 from flasgger import Swagger
 from flask_cors import CORS
 from wallet_entries import extract_wallet_entries
@@ -19,6 +19,12 @@ CORS(app, resources={r"/*": {"origins": [
     "http://localhost:8080", "https://localhost:8080"
 ]}})
 Swagger(app)
+
+
+@app.route("/")
+def index():
+    """Serve a simple HTML page for manual testing."""
+    return render_template("index.html")
 
 def extract_assets_data(driver, url):
     collapsed_tables = []

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,8 +26,13 @@
             document.getElementById('output').textContent = '';
             try {
                 const response = await fetch('/' + endpoint + '?' + params.toString());
-                const data = await response.text();
-                document.getElementById('output').textContent = data;
+                const text = await response.text();
+                try {
+                    const json = JSON.parse(text);
+                    document.getElementById('output').textContent = JSON.stringify(json, null, 2);
+                } catch {
+                    document.getElementById('output').textContent = text;
+                }
             } catch (err) {
                 document.getElementById('output').textContent = 'Error: ' + err;
             } finally {

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Investidor10 API Client</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        #loading { display: none; }
+        textarea { width: 100%; height: 200px; }
+    </style>
+    <script>
+        async function callAPI(endpoint) {
+            const urlInput = endpoint === 'wallet-entries' ? 'walletEntriesUrl' : 'walletUrl';
+            const url = document.getElementById(urlInput).value;
+            if (!url) {
+                alert('Please provide the URL.');
+                return;
+            }
+            const params = new URLSearchParams();
+            if (endpoint === 'wallet-entries') {
+                params.append('wallet_entries_url', url);
+            } else {
+                params.append('wallet_url', url);
+            }
+            document.getElementById('loading').style.display = 'block';
+            document.getElementById('output').textContent = '';
+            try {
+                const response = await fetch('/' + endpoint + '?' + params.toString());
+                const data = await response.text();
+                document.getElementById('output').textContent = data;
+            } catch (err) {
+                document.getElementById('output').textContent = 'Error: ' + err;
+            } finally {
+                document.getElementById('loading').style.display = 'none';
+            }
+        }
+    </script>
+</head>
+<body>
+    <h1>Investidor10 API Client</h1>
+    <div>
+        <h3>Wallet URL</h3>
+        <input type="text" id="walletUrl" placeholder="Wallet URL" style="width:100%">
+        <button onclick="callAPI('assets')">/assets</button>
+        <button onclick="callAPI('data-com')">/data-com</button>
+    </div>
+    <div style="margin-top:20px;">
+        <h3>Wallet Entries URL</h3>
+        <input type="text" id="walletEntriesUrl" placeholder="Wallet Entries URL" style="width:100%">
+        <button onclick="callAPI('wallet-entries')">/wallet-entries</button>
+    </div>
+    <p id="loading">Loading...</p>
+    <pre id="output"></pre>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- include a new HTML page to manually call API routes
- serve that page from Flask at `/`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886912d3288832c807e8f21704a73ed