### PR TITLE
Improve Selenium speed settings

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,4 @@
 import re
-import time
 import sys
 import os
 import json
@@ -9,7 +8,13 @@ from flask import Flask, jsonify, request, render_template
 from flasgger import Swagger
 from flask_cors import CORS
 from wallet_entries import extract_wallet_entries
-from utils import setup_driver, extract_table_header, extract_table_data
+from utils import (
+    setup_driver,
+    extract_table_header,
+    extract_table_data,
+    wait_for_page_load,
+    wait_for_element,
+)
 from datetime import datetime, date
 
 sys.stdout.reconfigure(line_buffering=True)
@@ -29,7 +34,7 @@ def index():
 def extract_assets_data(driver, url):
     collapsed_tables = []
     driver.get(url)
-    time.sleep(10)
+    wait_for_page_load(driver)
     try:
         assets_table = driver.find_element(By.CSS_SELECTOR, "table")
         header = extract_table_header(assets_table)
@@ -63,9 +68,8 @@ def extract_assets_data(driver, url):
                 driver.execute_script(
                     "arguments[0].scrollIntoView(true);", element
                 )
-                time.sleep(2)
                 driver.execute_script("arguments[0].click();", element)
-                time.sleep(10)
+                wait_for_element(driver, By.CSS_SELECTOR, selector)
                 container = driver.find_element(
                     By.CSS_SELECTOR, selector
                 )
@@ -208,7 +212,7 @@ def fetch_latest_data_com(assets_json) -> str:
             if not url:
                 continue
             driver.get(url)
-            time.sleep(10)
+            wait_for_element(driver, By.ID, 'table-dividends-history')
             try:
                 table = driver.find_element(By.ID, 'table-dividends-history')
             except NoSuchElementException:

--- a/utils.py
+++ b/utils.py
@@ -6,10 +6,19 @@ from selenium.webdriver.common.by import By
 
 def setup_driver():
     options = Options()
+    options.page_load_strategy = 'eager'
     options.add_argument('--headless')
     options.add_argument('--no-sandbox')
     options.add_argument('--disable-dev-shm-usage')
     options.add_argument('--remote-debugging-port=9222')
+    # Disable loading images, stylesheets and fonts to speed up page rendering
+    options.add_experimental_option(
+        'prefs', {
+            'profile.managed_default_content_settings.images': 2,
+            'profile.managed_default_content_settings.stylesheets': 2,
+            'profile.managed_default_content_settings.fonts': 2,
+        }
+    )
     options.binary_location = "/usr/bin/google-chrome"
     service = Service(executable_path="/usr/local/bin/chromedriver")
     driver = webdriver.Chrome(service=service, options=options)

--- a/utils.py
+++ b/utils.py
@@ -1,8 +1,9 @@
-import time
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 def setup_driver():
     options = Options()
@@ -25,6 +26,20 @@ def setup_driver():
     driver.set_page_load_timeout(300)
     driver.set_script_timeout(300)
     return driver
+
+
+def wait_for_page_load(driver, timeout=10):
+    """Wait until the current page is fully loaded."""
+    WebDriverWait(driver, timeout).until(
+        lambda d: d.execute_script("return document.readyState") == "complete"
+    )
+
+
+def wait_for_element(driver, by, value, timeout=10):
+    """Wait until a specific element is present in the DOM."""
+    WebDriverWait(driver, timeout).until(
+        EC.presence_of_element_located((by, value))
+    )
 
 def extract_table_header(table):
     try:

--- a/wallet_entries.py
+++ b/wallet_entries.py
@@ -1,5 +1,5 @@
 from selenium.webdriver.common.by import By
-import time
+from utils import wait_for_page_load
 
 def extract_table_header(table):
     header_elem = table.find_element(By.TAG_NAME, "thead")
@@ -31,9 +31,8 @@ def extract_detailed_table_data(driver, table, paginate_id=None):
                 if "disabled" in next_button.get_attribute("class"):
                     break
                 driver.execute_script("arguments[0].scrollIntoView(true);", next_button)
-                time.sleep(2)
                 driver.execute_script("arguments[0].click();", next_button)
-                time.sleep(10)
+                wait_for_page_load(driver)
                 row_elements = table.find_elements(By.CSS_SELECTOR, "tbody tr")
                 for row in row_elements:
                     row_class = row.get_attribute("class") or ""
@@ -74,7 +73,7 @@ def process_table(driver, table, index):
 def extract_wallet_entries(driver, url):
     print("Accessing wallet entries...")
     driver.get(url)
-    time.sleep(10)
+    wait_for_page_load(driver)
     tables = driver.find_elements(By.CSS_SELECTOR, "table")
     if len(tables) < 4:
         print("Insufficient tables found on the page.")

--- a/wallet_entries.py
+++ b/wallet_entries.py
@@ -1,5 +1,5 @@
 from selenium.webdriver.common.by import By
-from utils import wait_for_page_load
+from utils import wait_for_page_load, wait_for_element
 
 def extract_table_header(table):
     header_elem = table.find_element(By.TAG_NAME, "thead")
@@ -10,6 +10,7 @@ def extract_table_header(table):
 
 def extract_detailed_table_data(driver, table, paginate_id=None):
     detailed_rows = []
+    table_id = table.get_attribute("id")
     row_elements = table.find_elements(By.CSS_SELECTOR, "tbody tr")
     for row in row_elements:
         row_class = row.get_attribute("class") or ""
@@ -32,7 +33,11 @@ def extract_detailed_table_data(driver, table, paginate_id=None):
                     break
                 driver.execute_script("arguments[0].scrollIntoView(true);", next_button)
                 driver.execute_script("arguments[0].click();", next_button)
-                wait_for_page_load(driver)
+                if table_id:
+                    wait_for_element(driver, By.ID, table_id)
+                    table = driver.find_element(By.ID, table_id)
+                else:
+                    wait_for_page_load(driver)
                 row_elements = table.find_elements(By.CSS_SELECTOR, "tbody tr")
                 for row in row_elements:
                     row_class = row.get_attribute("class") or ""


### PR DESCRIPTION
## Summary
- reduce page load overhead by preventing stylesheets and fonts from loading
- set page_load_strategy to `eager`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887ff23fec8832c89c606ed1161e318