### PR TITLE
Improve web UI and persist wallet URLs

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -14,9 +14,6 @@
             margin: auto;
         }
 
-        #loading {
-            display: none;
-        }
 
         textarea {
             width: 100%;
@@ -40,6 +37,20 @@
         .desc {
             font-size: 0.9em;
             color: #555;
+        }
+
+        #output {
+            border: 1px solid #ddd;
+            background: #f9f9f9;
+            padding: 10px;
+            min-height: 200px;
+            white-space: pre-wrap;
+        }
+
+        #loading {
+            display: none;
+            font-style: italic;
+            color: #007bff;
         }
     </style>
     <script>
@@ -116,8 +127,11 @@
             <p class="desc">Simple health check endpoint.</p>
         </div>
 
-        <p id="loading">Loading...</p>
-        <pre id="output"></pre>
+        <div class="section">
+            <h3>Results</h3>
+            <p id="loading">Loading...</p>
+            <pre id="output"></pre>
+        </div>
     </div>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,24 +4,65 @@
     <meta charset="utf-8">
     <title>Investidor10 API Client</title>
     <style>
-        body { font-family: Arial, sans-serif; margin: 20px; }
-        #loading { display: none; }
-        textarea { width: 100%; height: 200px; }
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+        }
+
+        #container {
+            max-width: 700px;
+            margin: auto;
+        }
+
+        #loading {
+            display: none;
+        }
+
+        textarea {
+            width: 100%;
+            height: 200px;
+        }
+
+        input[type="text"] {
+            width: 100%;
+            padding: 8px;
+            margin-bottom: 10px;
+        }
+
+        button {
+            margin-right: 5px;
+        }
+
+        .section {
+            margin-top: 20px;
+        }
+
+        .desc {
+            font-size: 0.9em;
+            color: #555;
+        }
     </style>
     <script>
         async function callAPI(endpoint) {
             const urlInput = endpoint === 'wallet-entries' ? 'walletEntriesUrl' : 'walletUrl';
-            const url = document.getElementById(urlInput).value;
-            if (!url) {
+            const url = document.getElementById(urlInput).value.trim();
+            if (!url && endpoint !== 'test') {
                 alert('Please provide the URL.');
                 return;
             }
+
+            if (endpoint !== 'test') {
+                // persist URL for future visits
+                localStorage.setItem(urlInput, url);
+            }
+
             const params = new URLSearchParams();
             if (endpoint === 'wallet-entries') {
                 params.append('wallet_entries_url', url);
-            } else {
+            } else if (endpoint !== 'test') {
                 params.append('wallet_url', url);
             }
+
             document.getElementById('loading').style.display = 'block';
             document.getElementById('output').textContent = '';
             try {
@@ -39,22 +80,44 @@
                 document.getElementById('loading').style.display = 'none';
             }
         }
+
+        // preload stored values on first load
+        window.addEventListener('DOMContentLoaded', () => {
+            const wallet = localStorage.getItem('walletUrl');
+            const entries = localStorage.getItem('walletEntriesUrl');
+            if (wallet) document.getElementById('walletUrl').value = wallet;
+            if (entries) document.getElementById('walletEntriesUrl').value = entries;
+        });
     </script>
 </head>
 <body>
-    <h1>Investidor10 API Client</h1>
-    <div>
-        <h3>Wallet URL</h3>
-        <input type="text" id="walletUrl" placeholder="Wallet URL" style="width:100%">
-        <button onclick="callAPI('assets')">/assets</button>
-        <button onclick="callAPI('data-com')">/data-com</button>
+    <div id="container">
+        <h1>Investidor10 API Client</h1>
+        <p>Fill in your public wallet URLs and choose an endpoint.</p>
+
+        <div class="section">
+            <h3>Wallet URL</h3>
+            <input type="text" id="walletUrl" placeholder="Wallet URL">
+            <button onclick="callAPI('assets')">/assets</button>
+            <button onclick="callAPI('data-com')">/data-com</button>
+            <p class="desc">/assets returns the asset tables. /data-com lists upcoming dividend dates.</p>
+        </div>
+
+        <div class="section">
+            <h3>Wallet Entries URL</h3>
+            <input type="text" id="walletEntriesUrl" placeholder="Wallet Entries URL">
+            <button onclick="callAPI('wallet-entries')">/wallet-entries</button>
+            <p class="desc">/wallet-entries provides your order history.</p>
+        </div>
+
+        <div class="section">
+            <h3>Misc</h3>
+            <button onclick="callAPI('test')">/test</button>
+            <p class="desc">Simple health check endpoint.</p>
+        </div>
+
+        <p id="loading">Loading...</p>
+        <pre id="output"></pre>
     </div>
-    <div style="margin-top:20px;">
-        <h3>Wallet Entries URL</h3>
-        <input type="text" id="walletEntriesUrl" placeholder="Wallet Entries URL" style="width:100%">
-        <button onclick="callAPI('wallet-entries')">/wallet-entries</button>
-    </div>
-    <p id="loading">Loading...</p>
-    <pre id="output"></pre>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enhance styling and layout for the index page
- explain what each endpoint does in English
- keep wallet URLs in localStorage so inputs are pre-filled on next visit
- add optional `/test` call button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888badb6584832cb01d7eaede66cb01