### PR TITLE
Enrich data-com metadata and modernize asset scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Investidor10 API scraper
+# Painel de Insights da API Investidor10
 
-This project exposes a small Flask API that extracts data from public wallets on [Investidor10](https://investidor10.com.br/). You must have a publicly available wallet URL in order to use the endpoints.
+This project exposes a small Flask API that extracts data from public wallets on [Investidor10](https://investidor10.com.br/). You must have a publicly available wallet URL in order to use the endpoints. The API now retorna informações estruturadas por tipo de ativo e inclui detalhes adicionais na rota de datas‑com.
 
 ## Requirements
 
@@ -28,21 +28,36 @@ After starting, Swagger UI is available at `http://localhost:5000/apidocs`.
 
 ### `GET /wallet-entries`
 
-Fetch detailed order history from a wallet entries page.
+Fetch detailed order history from a wallet entries page (todas as tabelas paginadas de ordens, com o tipo da ordem prefixado em cada linha).
 Parameters:
 
 - `wallet_entries_url` – full URL to the wallet entries page on Investidor10.
 
 ### `GET /assets`
 
-Extract asset tables from a wallet page.
+Extract every asset table from a wallet page. Each returned table now inclui:
+
+- `table_name` – título exibido na carteira (ex.: Ações, FIIs, BDRs).
+- `header` – lista de colunas na ordem apresentada pela carteira.
+- `rows` – valores em formato de lista, preservando a ordem das colunas.
+- `structured_rows` – linhas como dicionários `coluna -> valor` para facilitar consumo programático.
+- `error` – mensagem de erro caso a tabela não seja acessível.
+
 Parameters:
 
 - `wallet_url` – full URL to the public wallet on Investidor10.
 
 ### `GET /data-com`
 
-Retrieve the upcoming ex-dividend dates for the assets in the wallet.
+Retrieve the upcoming ex-dividend dates for each asset in the wallet, enriched with metadata:
+
+- `asset` e `asset_name` – código e nome (quando disponível) do ativo.
+- `asset_type` – classificação derivada da tabela (Ação, FII, ETF, Criptomoeda, etc.).
+- `wallet_table` – nome da tabela de origem na carteira.
+- `asset_url` – link direto para a página do ativo no Investidor10.
+- `date_com` – próxima data‑com encontrada.
+- `dividend_details` – linha completa da tabela de histórico de dividendos para referência.
+
 Parameters:
 
 - `wallet_url` – full URL to the public wallet on Investidor10.
@@ -53,4 +68,4 @@ Simple health‑check endpoint returning a confirmation message.
 
 ## Notes
 
-Selenium is used under the hood, so requests may take some time while the pages are loaded and scraped.
+Selenium is used under the hood with estratégia de carregamento "eager" para reduzir o tempo de scraping. Mesmo assim, páginas mais pesadas podem levar alguns segundos para serem carregadas.

--- a/main.py
+++ b/main.py
@@ -1,15 +1,23 @@
 import re
 import sys
-from selenium.webdriver.common.by import By
-from selenium.common.exceptions import NoSuchElementException, TimeoutException
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import WebDriverWait
-from flask import Flask, jsonify, request, render_template
+from datetime import date, datetime
+from typing import Dict, List, Optional
+
+from flask import Flask, jsonify, render_template, request
 from flasgger import Swagger
 from flask_cors import CORS
+from selenium.common.exceptions import NoSuchElementException, TimeoutException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+from utils import (
+    convert_rows_to_text,
+    extract_structured_table_rows,
+    extract_table_headers,
+    setup_headless_chrome_driver,
+)
 from wallet_entries import extract_wallet_entries
-from utils import setup_driver, extract_table_header, extract_table_data
-from datetime import datetime, date
 
 sys.stdout.reconfigure(line_buffering=True)
 
@@ -33,22 +41,22 @@ def extract_assets_data(driver, url):
             EC.presence_of_element_located((By.CSS_SELECTOR, "table"))
         )
         assets_table = driver.find_element(By.CSS_SELECTOR, "table")
-        header = extract_table_header(assets_table)
-        assets_data = extract_table_data(assets_table)
+        header_labels = extract_table_headers(assets_table)
+        structured_rows = extract_structured_table_rows(assets_table, header_labels)
         collapsed_tables.append({
-            "table_name": "assets",
-            "header": header,
-            "rows": assets_data
+            "table_name": "Ações",
+            "header": header_labels,
+            "rows": convert_rows_to_text(structured_rows, header_labels),
+            "structured_rows": structured_rows,
         })
     except TimeoutException:
         collapsed_tables.append({
-            "table_name": "assets",
+            "table_name": "Ações",
             "error": "Tempo limite ao carregar a tabela principal de ativos."
         })
     except Exception as e:
-        print("Error:", str(e))
         collapsed_tables.append({
-            "table_name": "assets",
+            "table_name": "Ações",
             "error": str(e)
         })
     toggle_elements = driver.find_elements(
@@ -59,8 +67,8 @@ def extract_assets_data(driver, url):
             table_name = element.find_element(
                 By.CLASS_NAME, "name_value"
             ).text.strip()
-        except:
-            table_name = "Unknown Table"
+        except Exception:
+            table_name = "Tabela desconhecida"
         if "AÇÕES" in table_name.upper():
             continue
         onclick = element.get_attribute("onclick")
@@ -79,12 +87,13 @@ def extract_assets_data(driver, url):
                     By.CSS_SELECTOR, selector
                 )
                 table = container.find_element(By.TAG_NAME, "table")
-                header = extract_table_header(table)
-                rows = extract_table_data(table)
+                header_labels = extract_table_headers(table)
+                structured_rows = extract_structured_table_rows(table, header_labels)
                 collapsed_tables.append({
                     "table_name": table_name,
-                    "header": header,
-                    "rows": rows
+                    "header": header_labels,
+                    "rows": convert_rows_to_text(structured_rows, header_labels),
+                    "structured_rows": structured_rows,
                 })
             except TimeoutException:
                 collapsed_tables.append({
@@ -99,7 +108,7 @@ def extract_assets_data(driver, url):
         else:
             collapsed_tables.append({
                 "table_name": table_name,
-                "error": "Could not identify target selector"
+                "error": "Não foi possível identificar o seletor da tabela"
             })
     return collapsed_tables
 
@@ -119,7 +128,7 @@ def get_wallet_entries():
     data = request.get_json(silent=True) or request.args
     if "wallet_entries_url" not in data:
         return jsonify({"error": "wallet_entries_url parameter not provided"}), 400
-    driver = setup_driver()
+    driver = setup_headless_chrome_driver()
     try:
         result = extract_wallet_entries(driver, data["wallet_entries_url"])
         return jsonify(result)
@@ -146,22 +155,18 @@ def get_assets(wallet_url=None, jsonfy_return=True):
         if "wallet_url" not in data:
             return jsonify({"error": "wallet_url parameter not provided"}), 400
         wallet_url = data["wallet_url"]
-        
-    print("Executing /assets route...")
-    driver = setup_driver()
+
+    driver = setup_headless_chrome_driver()
     try:
         result = extract_assets_data(driver, wallet_url)
         if jsonfy_return:
             tables = []
             for tbl in result:
-                header_str = tbl.get('header', '')
-                rows_list = tbl.get('rows', [])
-                header = header_str.split(' | ') if header_str else []
-                rows = [row.split(' | ') for row in rows_list]
                 tables.append({
                     'table_name': tbl.get('table_name', ''),
-                    'header': header,
-                    'rows': rows,
+                    'header': tbl.get('header', []),
+                    'rows': [row.split(' | ') for row in tbl.get('rows', [])],
+                    'structured_rows': tbl.get('structured_rows', []),
                     'error': tbl.get('error')
                 })
             return jsonify({'tables': tables})
@@ -174,7 +179,7 @@ def get_assets(wallet_url=None, jsonfy_return=True):
 
 @app.route("/data-com", methods=["GET"])
 def get_data_com():
-    """Get the next dividend dates for wallet assets.
+    """Get the next dividend dates for wallet assets with metadata.
     ---
     parameters:
       - name: wallet_url
@@ -183,110 +188,206 @@ def get_data_com():
         required: true
     responses:
       200:
-        description: Upcoming dividend dates
+        description: Upcoming dividend dates enriched with asset type and origin table
     """
     data = request.get_json(silent=True) or request.args
     if "wallet_url" not in data:
         return jsonify({"error": "wallet_url parameter not provided"}), 400
-    
+
     try:
-        print("Executing get_data_com...")
-        data = get_assets(data["wallet_url"], False)
-        print("Data returned!")
+        assets_payload = get_assets(data["wallet_url"], False)
     except Exception as e:
         return jsonify({"error": str(e)}), 500
-    
+
     try:
-        print("Executing fetch_latest_data_com...")
-        result = fetch_latest_data_com(data)
-        print("fetch_latest_data_com RETURNED!!: ", result)
+        result = fetch_latest_data_com(assets_payload)
         return result
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
 def fetch_latest_data_com(assets_json):
-    if isinstance(assets_json, dict):
-        tables = assets_json.get('tables', [])
-    elif isinstance(assets_json, list):
-        tables = assets_json
-    else:
-        return jsonify({'error': 'invalid input format'}), 400
-    driver = setup_driver()
+    tables = extract_tables_from_assets_payload(assets_json)
+    driver = setup_headless_chrome_driver()
     results = []
     for tbl in tables:
         table_name = tbl.get('table_name', '')
-        for raw_row in tbl.get('rows', []):
-            row = raw_row.split(' | ') if isinstance(raw_row, str) else raw_row
-            code = row[0]
-            url = resolve_asset_url(code, table_name)
-            print(f"Resolving URL for {code}: {url}")
+        header_labels = tbl.get('header', [])
+        structured_rows = build_structured_rows(tbl)
+        for row in structured_rows:
+            ticker = resolve_ticker_from_row(row, header_labels)
+            asset_name = resolve_asset_name_from_row(row)
+            if not ticker:
+                continue
+            url = resolve_asset_url(ticker, table_name)
+            asset_type = derive_asset_type_from_table(table_name)
             if not url:
                 continue
-            driver.get(url)
-            try:
-                WebDriverWait(driver, 15).until(
-                    EC.presence_of_element_located((By.ID, 'table-dividends-history'))
-                )
-            except TimeoutException:
-                print(f"Timeout while waiting for dividends history for {code}.")
+            latest_dividend = fetch_latest_dividend_entry(driver, url)
+            if not latest_dividend:
                 continue
-            try:
-                table = driver.find_element(By.ID, 'table-dividends-history')
-            except NoSuchElementException:
-                print(f"Table not found for {code}.")
-                continue
-            dates = []
-            for tr in table.find_elements(By.CSS_SELECTOR, 'tbody tr'):
-                cells = tr.find_elements(By.TAG_NAME, 'td')
-                # print(f"Cells found: {len(cells)}")
-                if len(cells) < 2:
-                    continue
-                try:
-                    d = datetime.strptime(cells[1].text.strip(), '%d/%m/%Y')
-                    dates.append(d)
-                except:
-                    pass
-            if dates:
-                print(f"Dates found for {code}: {dates}")
-                latest = max(dates).strftime('%d/%m/%Y')
-                results.append({'asset': code, 'date_com': latest})
+            results.append({
+                'asset': ticker,
+                'asset_name': asset_name,
+                'asset_type': asset_type,
+                'wallet_table': table_name,
+                'asset_url': url,
+                'date_com': latest_dividend['date_com'],
+                'dividend_details': latest_dividend['row_snapshot'],
+            })
     driver.quit()
 
     today = date.today()
     filtered = []
     for item in results:
         try:
-            d = datetime.strptime(item['date_com'], '%d/%m/%Y').date()
+            parsed_date = datetime.strptime(item['date_com'], '%d/%m/%Y').date()
         except Exception:
             continue
-        if d >= today:
-            filtered.append({'asset': item['asset'], 'date_com': item['date_com'], 'd': d})
+        if parsed_date >= today:
+            filtered.append({**item, 'parsed_date': parsed_date})
 
-    filtered.sort(key=lambda x: x['d'])
-    sorted_results = [{'asset': f['asset'], 'date_com': f['date_com']} for f in filtered]
+    filtered.sort(key=lambda x: x['parsed_date'])
+    sorted_results = [
+        {
+            'asset': entry['asset'],
+            'asset_name': entry['asset_name'],
+            'asset_type': entry['asset_type'],
+            'wallet_table': entry['wallet_table'],
+            'asset_url': entry['asset_url'],
+            'date_com': entry['date_com'],
+            'dividend_details': entry['dividend_details'],
+        }
+        for entry in filtered
+    ]
 
     return jsonify(sorted_results)
 
-def resolve_asset_url(code: str, table_name: str) -> str:
+
+def extract_tables_from_assets_payload(assets_json) -> List[Dict]:
+    if isinstance(assets_json, dict):
+        return assets_json.get('tables', [])
+    if isinstance(assets_json, list):
+        return assets_json
+    return []
+
+
+def build_structured_rows(table_payload: Dict) -> List[Dict[str, str]]:
+    structured_rows: List[Dict[str, str]] = table_payload.get('structured_rows', []) or []
+    if structured_rows:
+        return structured_rows
+
+    header_labels = table_payload.get('header', []) or []
+    textual_rows: List[str] = table_payload.get('rows', []) or []
+    parsed_rows: List[Dict[str, str]] = []
+    for row in textual_rows:
+        parts = row.split(' | ')
+        row_dict: Dict[str, str] = {}
+        for index, value in enumerate(parts):
+            if index < len(header_labels):
+                row_dict[header_labels[index]] = value
+            else:
+                row_dict[f"column_{index + 1}"] = value
+        parsed_rows.append(row_dict)
+    return parsed_rows
+
+
+def resolve_ticker_from_row(row: Dict[str, str], header_labels: List[str]) -> Optional[str]:
+    prioritized_keys = [
+        'Código',
+        'Codigo',
+        'Ticker',
+        'Ativo',
+    ]
+    for key in prioritized_keys:
+        if key in row and row[key]:
+            return row[key]
+    if header_labels:
+        first_label = header_labels[0]
+        return row.get(first_label)
+    return next(iter(row.values()), None)
+
+
+def resolve_asset_name_from_row(row: Dict[str, str]) -> Optional[str]:
+    for key in ['Nome', 'Empresa', 'Descrição']:
+        if key in row and row[key]:
+            return row[key]
+    return None
+
+
+def derive_asset_type_from_table(table_name: str) -> str:
+    normalized = table_name.upper()
+    if 'FIIS' in normalized:
+        return 'Fundo Imobiliário'
+    if 'CRIPTO' in normalized:
+        return 'Criptomoeda'
+    if 'ETF' in normalized:
+        return 'ETF'
+    if 'STOCKS' in normalized:
+        return 'Ação Internacional'
+    if 'BDRS' in normalized:
+        return 'BDR'
+    return 'Ação'
+
+
+def fetch_latest_dividend_entry(driver, url: str) -> Optional[Dict[str, str]]:
+    driver.get(url)
+    try:
+        WebDriverWait(driver, 15).until(
+            EC.presence_of_element_located((By.ID, 'table-dividends-history'))
+        )
+    except TimeoutException:
+        return None
+    try:
+        table = driver.find_element(By.ID, 'table-dividends-history')
+    except NoSuchElementException:
+        return None
+
+    candidates: List[Dict[str, str]] = []
+    for tr in table.find_elements(By.CSS_SELECTOR, 'tbody tr'):
+        cells = tr.find_elements(By.TAG_NAME, 'td')
+        if len(cells) < 2:
+            continue
+        row_snapshot = [cell.text.strip() for cell in cells if cell.text.strip()]
+        try:
+            parsed_date = datetime.strptime(cells[1].text.strip(), '%d/%m/%Y')
+        except Exception:
+            continue
+        candidates.append({
+            'date_com': parsed_date.strftime('%d/%m/%Y'),
+            'row_snapshot': row_snapshot,
+            'parsed_date': parsed_date,
+        })
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda item: item['parsed_date'])
+    latest_candidate = candidates[-1]
+    return {
+        'date_com': latest_candidate['date_com'],
+        'row_snapshot': latest_candidate['row_snapshot'],
+    }
+
+
+def resolve_asset_url(code: str, table_name: str) -> Optional[str]:
     slug = code.lower()
-    if table_name == 'assets':
+    primary = table_name.split('\n')[0].upper()
+    if 'AÇÃO' in primary or 'AÇÕES' in primary or 'AÇÕES BR' in primary:
         path = 'acoes'
+    elif 'FIIS' in primary:
+        path = 'fiis'
+    elif 'CRIPTOMOEDA' in primary:
+        path = 'criptomoedas'
+    elif 'ETF' in primary and 'INTERN' in primary:
+        path = 'etfs-global'
+    elif 'ETF' in primary:
+        path = 'etfs'
+    elif 'STOCKS' in primary:
+        path = 'stocks'
+    elif 'BDR' in primary:
+        path = 'bdrs'
     else:
-        primary = table_name.split('\n')[0].upper()
-        if primary == 'FIIS':
-            path = 'fiis'
-        elif primary.startswith('CRIPTOMOEDAS'):
-            path = 'criptomoedas'
-        elif primary.startswith('ETFS INTERN'):
-            path = 'etfs-global'
-        elif primary.startswith('ETFS'):
-            path = 'etfs'
-        elif primary.startswith('STOCKS'):
-            path = 'stocks'
-        elif primary.startswith('BDRS'):
-            path = 'bdrs'
-        else:
-            return None
+        return None
     return f"https://investidor10.com.br/{path}/{slug}/"
 
 @app.route("/test", methods=["GET"])

--- a/templates/index.html
+++ b/templates/index.html
@@ -251,6 +251,7 @@
             border-radius: 14px;
             background: rgba(250, 204, 21, 0.08);
             border: 1px solid rgba(250, 204, 21, 0.3);
+            max-width: 100%;
         }
 
         .result-header {
@@ -292,6 +293,7 @@
             line-height: 1.6;
             color: var(--text-primary);
             white-space: pre-wrap;
+            word-break: break-word;
         }
 
         .raw-wrapper {
@@ -329,6 +331,10 @@
             overflow-x: auto;
             font-size: 13px;
             line-height: 1.5;
+            white-space: pre-wrap;
+            word-break: break-word;
+            max-height: 420px;
+            overflow: auto;
         }
 
         .activity-raw-wrapper {

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Ferramenta independente e não oficial para testar os endpoints da API Investidor10 usando URLs públicas da carteira.">
-    <meta property="og:title" content="Cliente não oficial da API Investidor10">
-    <meta property="og:description" content="Interaja com a API Investidor10 por meio desta ferramenta criada pela comunidade. Não é um produto oficial.">
+    <meta name="description" content="Painel independente para testar e inspecionar endpoints públicos da API Investidor10 usando carteiras abertas.">
+    <meta property="og:title" content="Painel de Insights da API Investidor10">
+    <meta property="og:description" content="Interaja com a API Investidor10 por meio deste painel de insights criado pela comunidade. Não é um produto oficial.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://investidor10.com.br/">
     <meta property="og:image" content="https://investidor10.com.br/static/logo-investidor10.png">
@@ -13,18 +13,18 @@
     {
         "@context": "https://schema.org",
         "@type": "WebApplication",
-        "name": "Cliente não oficial da API Investidor10",
+        "name": "Painel de Insights da API Investidor10",
         "url": "https://investidor10.com.br/",
         "applicationCategory": "FinanceApplication",
         "operatingSystem": "Any",
-        "description": "Ferramenta web independente, criada por membros da comunidade, para testar os endpoints públicos da API Investidor10.",
+        "description": "Painel web independente, criado por membros da comunidade, para testar os endpoints públicos da API Investidor10 e acompanhar datas de dividendos.",
         "creator": {
             "@type": "Person",
             "name": "Projeto comunitário não oficial"
         }
     }
     </script>
-    <title>Cliente não oficial da API Investidor10</title>
+    <title>Painel de Insights da API Investidor10</title>
     <style>
         :root {
             color-scheme: light dark;
@@ -607,8 +607,8 @@
 <body>
     <div class="app-shell">
         <header>
-            <h1>Cliente não oficial da API Investidor10</h1>
-            <p>Ferramenta independente criada por um entusiasta da comunidade Investidor10 — não é um produto oficial. Informe as URLs públicas da sua carteira e acompanhe cada requisição em tempo real, com os retornos guardados no painel lateral até você atualizar a página.</p>
+            <h1>Painel de Insights da API Investidor10</h1>
+            <p>Painel independente criado pela comunidade Investidor10 — não é um produto oficial. Cole as URLs públicas da carteira para receber tabelas estruturadas e datas‑com enriquecidas, com cada resposta arquivada no painel lateral.</p>
         </header>
 
         <main>

--- a/utils.py
+++ b/utils.py
@@ -1,37 +1,66 @@
-import time
+from typing import Dict, List
+
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
 
-def setup_driver():
-    options = Options()
-    options.add_argument('--headless')
-    options.add_argument('--no-sandbox')
-    options.add_argument('--disable-dev-shm-usage')
-    options.add_argument('--remote-debugging-port=9222')
-    options.binary_location = "/usr/bin/google-chrome"
-    service = Service(executable_path="/usr/local/bin/chromedriver")
-    driver = webdriver.Chrome(service=service, options=options)
-    driver.set_page_load_timeout(300)
-    driver.set_script_timeout(300)
-    return driver
 
-def extract_table_header(table):
+def setup_headless_chrome_driver() -> webdriver.Chrome:
+    chrome_options = Options()
+    chrome_options.add_argument("--headless")
+    chrome_options.add_argument("--no-sandbox")
+    chrome_options.add_argument("--disable-dev-shm-usage")
+    chrome_options.add_argument("--remote-debugging-port=9222")
+    chrome_options.set_capability("pageLoadStrategy", "eager")
+    chrome_options.binary_location = "/usr/bin/google-chrome"
+
+    chrome_service = Service(executable_path="/usr/local/bin/chromedriver")
+    chrome_driver = webdriver.Chrome(service=chrome_service, options=chrome_options)
+    chrome_driver.set_page_load_timeout(120)
+    chrome_driver.set_script_timeout(120)
+    return chrome_driver
+
+
+def extract_table_headers(table) -> List[str]:
     try:
         header_elem = table.find_element(By.TAG_NAME, "thead")
         header_row = header_elem.find_element(By.TAG_NAME, "tr")
         header_cols = header_row.find_elements(By.TAG_NAME, "th")
-        return " | ".join([col.text.strip() for col in header_cols if col.text.strip()])
+        return [col.text.strip() for col in header_cols if col.text.strip()]
     except Exception:
-        return ""
+        return []
 
-def extract_table_data(table):
+
+def extract_structured_table_rows(table, header_labels: List[str]) -> List[Dict[str, str]]:
     rows = table.find_elements(By.CSS_SELECTOR, "tbody tr")
-    data = []
+    structured_rows: List[Dict[str, str]] = []
     for row in rows:
-        cols = row.find_elements(By.TAG_NAME, "td")
-        row_data = [col.text.strip() for col in cols if col.text.strip()]
-        if row_data:
-            data.append(" | ".join(row_data))
-    return data
+        column_cells = row.find_elements(By.TAG_NAME, "td")
+        cleaned_values = [cell.text.strip() for cell in column_cells if cell.text.strip()]
+        if not cleaned_values:
+            continue
+
+        structured_row: Dict[str, str] = {}
+        for index, value in enumerate(cleaned_values):
+            if index < len(header_labels):
+                structured_row[header_labels[index]] = value
+            else:
+                structured_row[f"column_{index + 1}"] = value
+        structured_rows.append(structured_row)
+    return structured_rows
+
+
+def convert_rows_to_text(structured_rows: List[Dict[str, str]], header_labels: List[str]) -> List[str]:
+    serialized_rows: List[str] = []
+    for row in structured_rows:
+        ordered_values = [row.get(label, "") for label in header_labels]
+        extra_values = [
+            value
+            for key, value in row.items()
+            if key not in header_labels
+        ]
+        joined_values = " | ".join([*ordered_values, *extra_values]).strip(" |")
+        if joined_values:
+            serialized_rows.append(joined_values)
+    return serialized_rows


### PR DESCRIPTION
## Summary
- rename the UI to "Painel de Insights da API Investidor10" and refresh descriptive metadata
- refactor scraping utilities to produce structured table data and speed up Selenium with eager page loading
- enhance /data-com responses with asset type, name, source table, URLs, and dividend row details, updating docs accordingly

## Testing
- Not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e6797fdec832c8867b2280661ad34)