### PR TITLE
Add HTTP fallback for wallet asset extraction

### DIFF
--- a/CHANGES_SUMMARY.md
+++ b/CHANGES_SUMMARY.md
@@ -1,0 +1,18 @@
+# Resumo das Alterações Recentes
+
+## Extração de ativos via HTTP
+- Criada a rota de extração que primeiro tenta baixar o HTML diretamente com `requests` usando cabeçalhos de navegador e validação explícita de respostas proibidas (403) antes de processar.
+- O HTML é processado com BeautifulSoup para coletar a tabela principal e as tabelas colapsadas de ativos, com verificações de seletor e mensagens de erro claras quando estruturas esperadas não estão presentes.
+- Caso o módulo `bs4` não esteja disponível ou o HTML não contenha linhas utilizáveis, o fluxo abandona a abordagem HTTP e registra a queda para o Selenium.
+
+## Fallback garantido para Selenium/Chromium
+- Quando a extração HTTP não encontra linhas válidas, o sistema executa automaticamente o scraping com Selenium/Chromium para recuperar os dados completos.
+- A resolução de datas de "data-com" continua usando Selenium para navegar até as páginas de cada ativo e coletar o histórico de dividendos.
+- Portanto, o Chromium **não foi removido**; ele permanece como mecanismo de fallback e para as operações que dependem de navegação dinâmica.
+
+## Ajustes de tempo de execução
+- O tempo limite da interface foi restaurado para 1200 segundos, acomodando operações de scraping mais longas sem encerrar prematuramente as requisições.
+
+## Conformidade e robustez
+- Incluído `beautifulsoup4` nas dependências para permitir o parsing estático.
+- Melhorados logs para facilitar o diagnóstico de sucessos e quedas de HTTP para Selenium.

--- a/http_assets_extractor.py
+++ b/http_assets_extractor.py
@@ -4,6 +4,17 @@ from typing import List, Optional, Dict
 
 import requests
 
+DEFAULT_REQUEST_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Referer": "https://investidor10.com.br/",
+    "Connection": "keep-alive",
+}
+
 
 def extract_assets_via_http(wallet_url: str) -> List[Dict[str, str]]:
     html_content = fetch_wallet_html(wallet_url)
@@ -11,7 +22,13 @@ def extract_assets_via_http(wallet_url: str) -> List[Dict[str, str]]:
 
 
 def fetch_wallet_html(wallet_url: str) -> str:
-    response = requests.get(wallet_url, timeout=30)
+    response = requests.get(
+        wallet_url,
+        timeout=30,
+        headers=DEFAULT_REQUEST_HEADERS,
+    )
+    if response.status_code == 403:
+        raise requests.HTTPError("Forbidden while fetching wallet HTML", response=response)
     response.raise_for_status()
     return response.text
 

--- a/http_assets_extractor.py
+++ b/http_assets_extractor.py
@@ -1,0 +1,100 @@
+import re
+from typing import List, Optional, Dict
+
+import requests
+from bs4 import BeautifulSoup
+
+
+def extract_assets_via_http(wallet_url: str) -> List[Dict[str, str]]:
+    html_content = fetch_wallet_html(wallet_url)
+    return build_assets_from_static_html(html_content)
+
+
+def fetch_wallet_html(wallet_url: str) -> str:
+    response = requests.get(wallet_url, timeout=30)
+    response.raise_for_status()
+    return response.text
+
+
+def build_assets_from_static_html(html_content: str) -> List[Dict[str, str]]:
+    soup = BeautifulSoup(html_content, "html.parser")
+    collected_tables: List[Dict[str, str]] = []
+
+    primary_table = soup.select_one("table")
+    if primary_table:
+        collected_tables.append(
+            build_table_payload("assets", primary_table)
+        )
+
+    toggle_elements = soup.find_all(
+        lambda tag: tag.has_attr("onclick") and "MyWallets.toogleClass" in tag.get("onclick", "")
+    )
+
+    for toggle_element in toggle_elements:
+        table_name = extract_table_name(toggle_element)
+        if "AÇÕES" in table_name.upper():
+            continue
+
+        selector = extract_selector(toggle_element.get("onclick", ""))
+        if selector is None:
+            collected_tables.append(
+                {"table_name": table_name, "error": "Could not identify target selector"}
+            )
+            continue
+
+        table_container = soup.select_one(selector)
+        if table_container is None:
+            collected_tables.append(
+                {"table_name": table_name, "error": "Target selector not found in static HTML"}
+            )
+            continue
+
+        table_tag = table_container.find("table")
+        if table_tag is None:
+            collected_tables.append(
+                {"table_name": table_name, "error": "No table element found for selector"}
+            )
+            continue
+
+        collected_tables.append(build_table_payload(table_name, table_tag))
+
+    return collected_tables
+
+
+def build_table_payload(table_name: str, table_tag) -> Dict[str, str]:
+    header = parse_table_header_from_soup(table_tag)
+    rows = parse_table_rows_from_soup(table_tag)
+    return {
+        "table_name": table_name,
+        "header": header,
+        "rows": rows,
+    }
+
+
+def parse_table_header_from_soup(table_tag) -> str:
+    header_cells = table_tag.select("thead tr th")
+    header_values = [cell.get_text(strip=True) for cell in header_cells if cell.get_text(strip=True)]
+    return " | ".join(header_values)
+
+
+def parse_table_rows_from_soup(table_tag) -> List[str]:
+    parsed_rows: List[str] = []
+    for row in table_tag.select("tbody tr"):
+        cell_values = [cell.get_text(strip=True) for cell in row.find_all("td") if cell.get_text(strip=True)]
+        if cell_values:
+            parsed_rows.append(" | ".join(cell_values))
+    return parsed_rows
+
+
+def extract_table_name(toggle_element) -> str:
+    name_element = toggle_element.find(class_="name_value")
+    if name_element is None:
+        return "Unknown Table"
+    return name_element.get_text(strip=True) or "Unknown Table"
+
+
+def extract_selector(onclick_value: str) -> Optional[str]:
+    match = re.search(r"toogleClass\\\('([^']+)'", onclick_value)
+    if not match:
+        return None
+    return match.group(1)

--- a/http_dividends_extractor.py
+++ b/http_dividends_extractor.py
@@ -1,0 +1,44 @@
+import datetime
+from typing import List
+
+import requests
+
+from http_assets_extractor import DEFAULT_REQUEST_HEADERS, load_beautiful_soup_constructor
+
+
+def extract_dividend_dates_via_http(asset_url: str) -> List[datetime.date]:
+    page_html = _download_asset_page_html(asset_url)
+    if not page_html:
+        return []
+
+    beautiful_soup_constructor = load_beautiful_soup_constructor()
+    if beautiful_soup_constructor is None:
+        return []
+
+    soup = beautiful_soup_constructor(page_html, "html.parser")
+    dividends_table = soup.find(id="table-dividends-history")
+    if dividends_table is None:
+        return []
+
+    parsed_dates: List[datetime.date] = []
+    for row in dividends_table.select("tbody tr"):
+        date_cells = row.find_all("td")
+        if len(date_cells) < 2:
+            continue
+        parsed_date = _parse_brazilian_date(date_cells[1].get_text(strip=True))
+        if parsed_date:
+            parsed_dates.append(parsed_date)
+    return parsed_dates
+
+
+def _download_asset_page_html(asset_url: str) -> str:
+    response = requests.get(asset_url, headers=DEFAULT_REQUEST_HEADERS, timeout=30)
+    response.raise_for_status()
+    return response.text
+
+
+def _parse_brazilian_date(date_value: str) -> datetime.date | None:
+    try:
+        return datetime.datetime.strptime(date_value, "%d/%m/%Y").date()
+    except Exception:
+        return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Flask>=2.0.0
 flask-cors
 requests
 flasgger
+beautifulsoup4

--- a/templates/index.html
+++ b/templates/index.html
@@ -667,7 +667,7 @@
                             </div>
                             <div class="timeout-controls">
                                 <label for="requestTimeout">Tempo limite (s)</label>
-                                <input type="number" id="requestTimeout" min="5" step="5" value="120">
+                                <input type="number" id="requestTimeout" min="5" step="5" value="1200">
                             </div>
                             <div id="resultContent" class="result-text"></div>
                             <button type="button" id="toggleRaw" class="toggle-raw" hidden>Mostrar resposta completa</button>
@@ -755,7 +755,7 @@
             error: 'Ocorreu um erro'
         };
 
-        const DEFAULT_TIMEOUT_SECONDS = timeoutInput ? Number(timeoutInput.value) || 120 : 120;
+        const DEFAULT_TIMEOUT_SECONDS = timeoutInput ? Number(timeoutInput.value) || 1200 : 1200;
 
         let activeController = null;
         let countdownInterval = null;


### PR DESCRIPTION
## Summary
- add an HTTP-based asset extraction path using BeautifulSoup to parse wallet pages without Selenium
- update the /assets route to prefer static HTML parsing and only fall back to the Chromium driver when necessary
- include BeautifulSoup as a dependency for HTML parsing

## Testing
- not run (per instructions)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c9cf3a2b4832c877b5f62b1a920e6)