### PR TITLE
Continue /data-com processing on per-asset failures and return failure info

### DIFF
--- a/data_com_jobs.py
+++ b/data_com_jobs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import threading
 import time
 from dataclasses import dataclass, field
-from datetime import date
+from datetime import date, datetime, timezone
 from typing import Dict, List, Optional
 from uuid import uuid4
 
@@ -147,7 +147,8 @@ class DataComJobProgressUpdater:
     def mark_running(self) -> None:
         self._job_store.mark_running(self._job_id, self._total_assets)
         print(
-            f"[data-com][job {self._job_id}] Iniciando processamento de {self._total_assets} ativos."
+            f"{_format_log_timestamp()} [data-com][job {self._job_id}] "
+            f"Iniciando processamento de {self._total_assets} ativos."
         )
 
     def report_progress(
@@ -167,13 +168,20 @@ class DataComJobProgressUpdater:
             message,
         )
         print(
-            f"[data-com][job {self._job_id}] {message} ({processed_assets}/{self._total_assets})."
+            f"{_format_log_timestamp()} [data-com][job {self._job_id}] "
+            f"{message} ({processed_assets}/{self._total_assets})."
         )
 
     def mark_completed(self, results: List[Dict[str, str]], failures: List[Dict[str, str]]) -> None:
         self._job_store.complete_job(self._job_id, results, failures)
-        print(f"[data-com][job {self._job_id}] Processamento concluído.")
+        print(f"{_format_log_timestamp()} [data-com][job {self._job_id}] Processamento concluído.")
 
     def mark_failed(self, error_message: str) -> None:
         self._job_store.fail_job(self._job_id, error_message)
-        print(f"[data-com][job {self._job_id}] Falha: {error_message}")
+        print(
+            f"{_format_log_timestamp()} [data-com][job {self._job_id}] Falha: {error_message}"
+        )
+
+
+def _format_log_timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S %z")

--- a/data_com_jobs.py
+++ b/data_com_jobs.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Dict, List, Optional
+from uuid import uuid4
+
+
+@dataclass
+class DataComJobResult:
+    status: str
+    results: List[Dict[str, str]] = field(default_factory=list)
+    failures: List[Dict[str, str]] = field(default_factory=list)
+    error_message: Optional[str] = None
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+
+
+class DataComJobStore:
+    def __init__(self) -> None:
+        self._jobs: Dict[str, DataComJobResult] = {}
+        self._lock = threading.Lock()
+
+    def create_job(self) -> str:
+        job_id = str(uuid4())
+        with self._lock:
+            self._jobs[job_id] = DataComJobResult(status="pending")
+        return job_id
+
+    def mark_running(self, job_id: str) -> None:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job:
+                job.status = "running"
+                job.updated_at = time.time()
+
+    def complete_job(
+        self,
+        job_id: str,
+        results: List[Dict[str, str]],
+        failures: List[Dict[str, str]],
+    ) -> None:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job:
+                job.status = "completed"
+                job.results = results
+                job.failures = failures
+                job.updated_at = time.time()
+
+    def fail_job(self, job_id: str, error_message: str) -> None:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job:
+                job.status = "failed"
+                job.error_message = error_message
+                job.updated_at = time.time()
+
+    def get_job(self, job_id: str) -> Optional[DataComJobResult]:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if not job:
+                return None
+            return DataComJobResult(
+                status=job.status,
+                results=list(job.results),
+                failures=list(job.failures),
+                error_message=job.error_message,
+                created_at=job.created_at,
+                updated_at=job.updated_at,
+            )
+
+
+@dataclass
+class CachedDividendDate:
+    date_com_date: date
+    cached_at: float
+
+
+class DividendDateCache:
+    def __init__(self, ttl_seconds: float) -> None:
+        self._ttl_seconds = ttl_seconds
+        self._entries: Dict[str, CachedDividendDate] = {}
+        self._lock = threading.Lock()
+
+    def get(self, cache_key: str) -> Optional[date]:
+        with self._lock:
+            cached_entry = self._entries.get(cache_key)
+            if not cached_entry:
+                return None
+            if time.time() - cached_entry.cached_at > self._ttl_seconds:
+                del self._entries[cache_key]
+                return None
+            return cached_entry.date_com_date
+
+    def set(self, cache_key: str, date_com_date: date) -> None:
+        with self._lock:
+            self._entries[cache_key] = CachedDividendDate(
+                date_com_date=date_com_date,
+                cached_at=time.time(),
+            )

--- a/main.py
+++ b/main.py
@@ -85,7 +85,7 @@ def _extract_timeout_seconds(data: Dict[str, object]) -> float:
         raw_timeout = float(data.get("timeout_seconds", 60))
     except (TypeError, ValueError):
         return 60
-    return max(5.0, min(raw_timeout, 55.0))
+    return max(5.0, min(raw_timeout, 300.0))
 
 
 def _resolve_wait_seconds(time_budget: Optional[TimeBudget], requested_seconds: float) -> float:

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import re
 import sys
 import time
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Dict, List, Optional
 from threading import Thread
 
@@ -347,7 +347,10 @@ def start_data_com_job(wallet_url: str, timeout_seconds: float) -> str:
     def run_job() -> None:
         time_budget = TimeBudget(timeout_seconds)
         try:
-            print(f"[data-com][job {job_id}] Iniciando coleta de ativos para {wallet_url}.")
+            print(
+                f"{datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S %z')} "
+                f"[data-com][job {job_id}] Iniciando coleta de ativos para {wallet_url}."
+            )
             tables = collect_assets_tables(wallet_url, time_budget)
             total_assets = count_assets_in_tables(tables)
             progress_updater = DataComJobProgressUpdater(

--- a/templates/index.html
+++ b/templates/index.html
@@ -107,20 +107,19 @@
             max-width: 720px;
         }
 
-        main {
+        .layout-grid {
             display: grid;
-            grid-template-columns: minmax(0, 1fr);
             gap: 20px;
             min-height: 0;
         }
 
-        main > * {
+        .layout-grid > * {
             min-width: 0;
         }
 
         @media (min-width: 960px) {
-            main {
-                grid-template-columns: minmax(0, 1.75fr) minmax(320px, 360px);
+            .layout-grid {
+                grid-template-columns: minmax(0, 1.1fr) minmax(0, 1.3fr);
                 align-items: stretch;
             }
         }
@@ -140,7 +139,8 @@
             }
         }
 
-        .inputs-grid {
+        .request-grid,
+        .result-grid {
             display: grid;
             gap: clamp(16px, 2vw, 24px);
         }
@@ -416,31 +416,6 @@
             word-break: break-word;
         }
 
-        .activity-raw-wrapper {
-            margin-top: 12px;
-            max-width: 100%;
-            min-width: 0;
-        }
-
-        .activity-raw-wrapper .result-raw {
-            font-size: 12px;
-            padding-top: 52px;
-            max-height: 220px;
-            overflow: auto;
-        }
-
-        .activity-raw-wrapper .raw-toolbar {
-            position: static;
-            flex-wrap: wrap;
-            justify-content: flex-start;
-            margin-bottom: 8px;
-        }
-
-        .activity-raw-wrapper .raw-action {
-            white-space: normal;
-            text-align: center;
-        }
-
         .modal-overlay {
             position: fixed;
             inset: 0;
@@ -546,100 +521,6 @@
             background: rgba(250, 204, 21, 0.1);
         }
 
-        .activity-panel {
-            display: flex;
-            flex-direction: column;
-            gap: 18px;
-            height: 100%;
-            min-height: 0;
-            min-width: 0;
-        }
-
-        .activity-panel h2 {
-            margin: 0;
-            font-size: 18px;
-        }
-
-        .activity-feed-container {
-            display: flex;
-            flex-direction: column;
-            gap: 12px;
-            flex: 1;
-            min-height: 0;
-            min-width: 0;
-        }
-
-        .activity-feed-actions {
-            display: flex;
-            justify-content: flex-end;
-        }
-
-        .activity-feed {
-            display: grid;
-            gap: 12px;
-            overflow-y: auto;
-            overflow-x: hidden;
-            padding-right: 4px;
-            flex: 1;
-            min-height: 0;
-            align-content: start;
-            min-width: 0;
-        }
-
-        .activity-entry {
-            display: grid;
-            gap: 6px;
-            padding: 14px 16px;
-            border-radius: 14px;
-            background: rgba(250, 204, 21, 0.12);
-            border: 1px solid transparent;
-            word-break: break-word;
-            max-width: 100%;
-            min-width: 0;
-        }
-
-        .activity-entry p,
-        .activity-entry strong,
-        .activity-entry pre {
-            word-break: break-word;
-            overflow-wrap: anywhere;
-            max-width: 100%;
-        }
-
-        .activity-entry.info {
-            border-color: rgba(250, 204, 21, 0.28);
-        }
-
-        .activity-entry.success {
-            border-color: rgba(16, 185, 129, 0.18);
-        }
-
-        .activity-entry.error {
-            border-color: rgba(239, 68, 68, 0.18);
-        }
-
-        .activity-entry strong {
-            font-size: 14px;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-            color: rgba(250, 204, 21, 0.85);
-        }
-
-        .activity-entry p {
-            margin: 0;
-            font-size: 14px;
-            line-height: 1.6;
-        }
-
-        .empty-state {
-            text-align: center;
-            color: rgba(249, 250, 251, 0.72);
-            font-size: 14px;
-            padding: 20px;
-            border: 1px dashed rgba(250, 204, 21, 0.4);
-            border-radius: 12px;
-        }
-
         .links {
             display: inline-flex;
             gap: 8px;
@@ -722,12 +603,12 @@
     <div class="app-shell">
         <header>
             <h1>Cliente não oficial da API Investidor10</h1>
-            <p>Ferramenta independente criada por um entusiasta da comunidade Investidor10 — não é um produto oficial. Informe as URLs públicas da sua carteira e acompanhe cada requisição em tempo real, com os retornos guardados no painel lateral até você atualizar a página.</p>
+            <p>Ferramenta independente criada por um entusiasta da comunidade Investidor10 — não é um produto oficial. Informe as URLs públicas da sua carteira, execute as rotas desejadas e acompanhe o progresso e os resultados em tempo real no painel ao lado.</p>
         </header>
 
-        <main>
-            <section class="panel" aria-label="Configurações e execução de requisições">
-                <div class="inputs-grid">
+        <main class="layout-grid">
+            <section class="panel request-panel" aria-label="Configurações e execução de requisições">
+                <div class="request-grid">
                     <article class="card">
                         <div>
                             <label for="walletUrl">Wallet URL</label>
@@ -756,9 +637,13 @@
                         <div class="button-row" role="group" aria-label="Ações gerais">
                             <button type="button" class="secondary" data-endpoint="test">Executar /test</button>
                         </div>
-                        <p class="desc">Use o teste para verificar se a API está respondendo corretamente. Quando uma requisição estiver em andamento, aguarde ou cancele antes de iniciar outra.</p>
+                        <p class="desc">Use o teste para verificar se a API está respondendo corretamente. Quando uma requisição estiver em andamento, aguarde até a conclusão antes de iniciar outra.</p>
                     </article>
+                </div>
+            </section>
 
+            <section class="panel result-panel" aria-label="Resultados e acompanhamento">
+                <div class="result-grid">
                     <article class="card">
                         <div class="result-wrapper" aria-live="polite">
                             <div class="result-header">
@@ -777,6 +662,7 @@
                                     </span>
                                     <span id="resultStatus" class="status-pill">Aguardando</span>
                                     <button type="button" class="danger" id="cancelRequest" disabled hidden>Cancelar requisição</button>
+                                    <button type="button" class="secondary" id="viewStructuredInline" disabled>Ver em tabela</button>
                                 </div>
                             </div>
                             <div class="timeout-controls">
@@ -846,16 +732,6 @@
                 </div>
             </section>
 
-            <aside class="panel activity-panel" aria-label="Linha do tempo das requisições">
-                <div class="activity-feed-container">
-                    <div class="activity-feed-actions">
-                        <button type="button" class="secondary" id="clearActivity">Limpar histórico</button>
-                    </div>
-                    <div id="activityFeed" class="activity-feed" aria-live="polite">
-                        <div class="empty-state" id="activityEmpty">Nenhuma atividade registrada até o momento.</div>
-                    </div>
-                </div>
-            </aside>
         </main>
 
         <div id="jsonModal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="jsonModalTitle">
@@ -884,9 +760,7 @@
         const rawWrapper = document.getElementById('rawWrapper');
         const copyRawButton = document.getElementById('copyRaw');
         const viewStructuredButton = document.getElementById('viewStructured');
-        const activityFeed = document.getElementById('activityFeed');
-        const activityEmpty = document.getElementById('activityEmpty');
-        const clearActivity = document.getElementById('clearActivity');
+        const viewStructuredInlineButton = document.getElementById('viewStructuredInline');
         const cancelRequest = document.getElementById('cancelRequest');
         const loadingIndicator = document.getElementById('loadingIndicator');
         const timeoutInput = document.getElementById('requestTimeout');
@@ -925,9 +799,9 @@
         let abortReason = null;
         let copyFeedbackTimer = null;
         let dataComPollingTimer = null;
-        let dataComLastStatus = null;
         const dataComResultsIndex = new Map();
         const dataComFailuresIndex = new Map();
+        let dataComJobActive = false;
 
         function persistInputs() {
             localStorage.setItem(STORAGE_KEYS.wallet, walletInput.value.trim());
@@ -939,63 +813,6 @@
             const entries = localStorage.getItem(STORAGE_KEYS.entries);
             if (wallet) walletInput.value = wallet;
             if (entries) entriesInput.value = entries;
-        }
-
-        function addActivityEntry({ title, message, status, raw }) {
-            if (activityEmpty) {
-                activityEmpty.remove();
-            }
-            const container = document.createElement('div');
-            container.className = `activity-entry ${status}`;
-
-            const heading = document.createElement('strong');
-            heading.textContent = `${new Date().toLocaleTimeString()} · ${title}`;
-
-            const description = document.createElement('p');
-            description.textContent = message;
-
-            container.appendChild(heading);
-            container.appendChild(description);
-
-            if (raw) {
-                const rawWrapper = document.createElement('div');
-                rawWrapper.className = 'raw-wrapper activity-raw-wrapper';
-
-                const toolbar = document.createElement('div');
-                toolbar.className = 'raw-toolbar';
-
-                const copyButton = document.createElement('button');
-                copyButton.type = 'button';
-                copyButton.className = 'raw-action';
-                copyButton.textContent = 'Copiar JSON';
-                copyButton.addEventListener('click', () => {
-                    copyRawToClipboard(raw, copyButton);
-                });
-
-                const viewButton = document.createElement('button');
-                viewButton.type = 'button';
-                viewButton.className = 'raw-action';
-                viewButton.textContent = 'Ver em tabela';
-                viewButton.addEventListener('click', () => {
-                    openJsonModalWithStructuredContent(raw);
-                });
-
-                toolbar.appendChild(copyButton);
-                toolbar.appendChild(viewButton);
-
-                const rawPreview = document.createElement('pre');
-                rawPreview.className = 'result-raw';
-                rawPreview.textContent = raw;
-                rawPreview.style.maxHeight = '220px';
-                rawPreview.style.overflow = 'auto';
-
-                rawWrapper.appendChild(toolbar);
-                rawWrapper.appendChild(rawPreview);
-                container.appendChild(rawWrapper);
-            }
-
-            activityFeed.prepend(container);
-            activityFeed.scrollTop = 0;
         }
 
         function resetDataComProgressSection() {
@@ -1027,6 +844,26 @@
             }
             if (dataComProgress) {
                 dataComProgress.classList.add('hidden');
+            }
+        }
+
+        function setAsyncDataComLock(isLocked) {
+            dataComJobActive = isLocked;
+            buttons.forEach((button) => {
+                button.disabled = isLocked;
+            });
+            if (walletInput) {
+                walletInput.disabled = isLocked;
+            }
+            if (entriesInput) {
+                entriesInput.disabled = isLocked;
+            }
+            if (timeoutInput) {
+                timeoutInput.disabled = isLocked;
+            }
+            if (cancelRequest) {
+                cancelRequest.disabled = true;
+                cancelRequest.hidden = true;
             }
         }
 
@@ -1134,7 +971,7 @@
             stopDataComPolling();
             resetDataComProgressSection();
             showDataComProgressSection(jobId);
-            dataComLastStatus = null;
+            setAsyncDataComLock(true);
 
             const pollStatus = async () => {
                 try {
@@ -1152,18 +989,9 @@
                         raw: JSON.stringify(payload, null, 2)
                     });
 
-                    if (payload.status !== dataComLastStatus) {
-                        dataComLastStatus = payload.status;
-                        addActivityEntry({
-                            title: `Status do job ${jobId}`,
-                            message: payload.last_message || `Status: ${payload.status}`,
-                            status: payload.status === 'failed' ? 'error' : 'info',
-                            raw: JSON.stringify(payload, null, 2)
-                        });
-                    }
-
                     if (payload.status === 'completed' || payload.status === 'failed') {
                         stopDataComPolling();
+                        setAsyncDataComLock(false);
                         updateResult({
                             status: payload.status === 'completed' ? 'success' : 'error',
                             description: payload.status === 'completed'
@@ -1175,11 +1003,7 @@
                     }
                 } catch (error) {
                     stopDataComPolling();
-                    addActivityEntry({
-                        title: 'Erro ao consultar status',
-                        message: 'Não foi possível atualizar o status do job do /data-com.',
-                        status: 'error'
-                    });
+                    setAsyncDataComLock(false);
                 }
             };
 
@@ -1215,6 +1039,9 @@
                 if (viewStructuredButton) {
                     viewStructuredButton.disabled = false;
                 }
+                if (viewStructuredInlineButton) {
+                    viewStructuredInlineButton.disabled = false;
+                }
                 if (jsonModal && !jsonModal.classList.contains('hidden') && jsonModalBody) {
                     jsonModalBody.innerHTML = '';
                     jsonModalBody.appendChild(renderJsonStructured(raw));
@@ -1235,6 +1062,9 @@
                 }
                 if (viewStructuredButton) {
                     viewStructuredButton.disabled = true;
+                }
+                if (viewStructuredInlineButton) {
+                    viewStructuredInlineButton.disabled = true;
                 }
                 closeJsonModal();
             }
@@ -1589,7 +1419,7 @@
 
         function setRequestState(isRunning) {
             buttons.forEach((button) => {
-                button.disabled = isRunning;
+                button.disabled = isRunning || dataComJobActive;
             });
             if (cancelRequest) {
                 cancelRequest.disabled = !isRunning;
@@ -1606,6 +1436,10 @@
 
         async function handleEndpointClick(event) {
             if (activeController) {
+                return;
+            }
+            if (dataComJobActive) {
+                alert('O processamento assíncrono do /data-com está em andamento. Aguarde a conclusão para iniciar outra requisição.');
                 return;
             }
             const endpoint = event.currentTarget.dataset.endpoint;
@@ -1715,12 +1549,6 @@
                 }
             }, timeoutMs);
 
-            addActivityEntry({
-                title: `Chamando ${endpoint}`,
-                message: `Enviando requisição para a API (tempo limite de ${timeoutSeconds}s)…`,
-                status: 'info'
-            });
-
             updateResult({
                 status: 'loading',
                 description: `Consultando o endpoint ${endpoint}. Aguarde…`,
@@ -1742,22 +1570,9 @@
                     raw: interpretation.raw
                 });
 
-                addActivityEntry({
-                    title: succeeded ? 'Sucesso' : 'Erro',
-                    message: succeeded ? `Recebemos uma resposta do endpoint ${endpoint}.` : `Status ${response.status} ao consultar ${endpoint}.`,
-                    status: succeeded ? 'success' : 'error',
-                    raw: interpretation.raw
-                });
-
                 if (endpoint === 'data-com' && parsedResponse && parsedResponse.job_id) {
                     resetDataComProgressSection();
                     showDataComProgressSection(parsedResponse.job_id);
-                    addActivityEntry({
-                        title: 'Job iniciado para /data-com',
-                        message: `Job ${parsedResponse.job_id} criado. Aguardando o processamento em segundo plano.`,
-                        status: 'info',
-                        raw: interpretation.raw
-                    });
                     updateResult({
                         status: 'loading',
                         description: 'Job criado. Estamos buscando os ativos em segundo plano.',
@@ -1783,12 +1598,6 @@
                         content: '',
                         raw: null
                     });
-
-                    addActivityEntry({
-                        title: wasTimeout ? 'Tempo limite excedido' : 'Cancelada',
-                        message,
-                        status: wasTimeout ? 'error' : 'info'
-                    });
                 } else {
                     const message = 'Não foi possível concluir a requisição. Verifique sua conexão e tente novamente.';
 
@@ -1797,12 +1606,6 @@
                         description: message,
                         content: String(error),
                         raw: null
-                    });
-
-                    addActivityEntry({
-                        title: 'Erro de rede',
-                        message,
-                        status: 'error'
                     });
                 }
             } finally {
@@ -1826,6 +1629,10 @@
             viewStructuredButton.addEventListener('click', openJsonModalWithStructuredView);
         }
 
+        if (viewStructuredInlineButton) {
+            viewStructuredInlineButton.addEventListener('click', openJsonModalWithStructuredView);
+        }
+
         modalCloseButtons.forEach((button) => button.addEventListener('click', closeJsonModal));
 
         if (jsonModal) {
@@ -1840,12 +1647,6 @@
             if (event.key === 'Escape' && jsonModal && !jsonModal.classList.contains('hidden')) {
                 closeJsonModal();
             }
-        });
-
-        clearActivity.addEventListener('click', () => {
-            activityFeed.innerHTML = '';
-            activityFeed.appendChild(activityEmpty);
-            activityEmpty.textContent = 'Histórico limpo. Execute uma nova requisição para ver os status novamente.';
         });
 
         if (cancelRequest) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -952,6 +952,62 @@
             }
         }
 
+        function openDataComResultsModal() {
+            if (!jsonModal || !jsonModalBody) {
+                return;
+            }
+            if (dataComResultsIndex.size === 0) {
+                const emptyMessage = document.createElement('p');
+                emptyMessage.textContent = 'Nenhum resultado bem-sucedido disponível para exibir.';
+                emptyMessage.className = 'desc';
+                jsonModalBody.innerHTML = '';
+                jsonModalBody.appendChild(emptyMessage);
+                jsonModal.classList.remove('hidden');
+                return;
+            }
+
+            const tableSection = document.createElement('section');
+            tableSection.style.display = 'grid';
+            tableSection.style.gap = '12px';
+
+            const heading = document.createElement('h3');
+            heading.textContent = 'Resultados bem-sucedidos do /data-com';
+            heading.style.margin = '0';
+            heading.style.fontSize = '16px';
+            heading.style.color = 'var(--accent)';
+            tableSection.appendChild(heading);
+
+            const table = document.createElement('table');
+            const thead = document.createElement('thead');
+            const headerRow = document.createElement('tr');
+            ['Ativo', 'Data-com'].forEach((label) => {
+                const th = document.createElement('th');
+                th.textContent = label;
+                headerRow.appendChild(th);
+            });
+            thead.appendChild(headerRow);
+            table.appendChild(thead);
+
+            const tbody = document.createElement('tbody');
+            Array.from(dataComResultsIndex.entries()).forEach(([asset, row]) => {
+                const dateText = row.children[1]?.textContent ?? '-';
+                const tr = document.createElement('tr');
+                const assetCell = document.createElement('td');
+                assetCell.textContent = asset;
+                const dateCell = document.createElement('td');
+                dateCell.textContent = dateText;
+                tr.appendChild(assetCell);
+                tr.appendChild(dateCell);
+                tbody.appendChild(tr);
+            });
+            table.appendChild(tbody);
+            tableSection.appendChild(table);
+
+            jsonModalBody.innerHTML = '';
+            jsonModalBody.appendChild(tableSection);
+            jsonModal.classList.remove('hidden');
+        }
+
         function parseJsonSafely(text) {
             try {
                 return JSON.parse(text);
@@ -1630,7 +1686,13 @@
         }
 
         if (viewStructuredInlineButton) {
-            viewStructuredInlineButton.addEventListener('click', openJsonModalWithStructuredView);
+            viewStructuredInlineButton.addEventListener('click', () => {
+                if (dataComResultsIndex.size > 0) {
+                    openDataComResultsModal();
+                } else {
+                    openJsonModalWithStructuredView();
+                }
+            });
         }
 
         modalCloseButtons.forEach((button) => button.addEventListener('click', closeJsonModal));

--- a/templates/index.html
+++ b/templates/index.html
@@ -343,6 +343,8 @@
             border-radius: 12px;
             border: 1px solid rgba(148, 163, 184, 0.25);
             padding: 12px;
+            max-width: 100%;
+            overflow: hidden;
         }
 
         .data-com-progress-table h3 {
@@ -355,6 +357,7 @@
             width: 100%;
             border-collapse: collapse;
             font-size: 13px;
+            min-width: 560px;
         }
 
         .data-com-progress-table th,
@@ -362,6 +365,17 @@
             padding: 8px 10px;
             border-bottom: 1px solid rgba(148, 163, 184, 0.2);
             text-align: left;
+        }
+
+        .table-scroll-wrapper {
+            overflow-x: auto;
+            max-width: 100%;
+        }
+
+        .table-scroll-wrapper table {
+            width: 100%;
+            min-width: 680px;
+            border-collapse: collapse;
         }
 
         .data-com-progress-table th {
@@ -1255,6 +1269,8 @@
             }
 
             if (Array.isArray(table.header) && Array.isArray(table.rows)) {
+                const tableWrapper = document.createElement('div');
+                tableWrapper.className = 'table-scroll-wrapper';
                 const tableElement = document.createElement('table');
                 if (table.header.length) {
                     const thead = document.createElement('thead');
@@ -1292,7 +1308,8 @@
                     tbody.appendChild(tr);
                 });
                 tableElement.appendChild(tbody);
-                section.appendChild(tableElement);
+                tableWrapper.appendChild(tableElement);
+                section.appendChild(tableWrapper);
             } else {
                 const fallback = document.createElement('pre');
                 fallback.textContent = JSON.stringify(table, null, 2);
@@ -1345,6 +1362,31 @@
             }
 
             return buildTableSection(tableData, 0);
+        }
+
+        function buildWalletEntriesTableSection(tablePayload, index) {
+            const headerValue = tablePayload && typeof tablePayload.header === 'string'
+                ? tablePayload.header.split(' | ').filter(Boolean)
+                : [];
+            const rowsValue = Array.isArray(tablePayload?.rows) ? tablePayload.rows : [];
+            const normalizedRows = rowsValue.map((rowItem) => {
+                if (typeof rowItem === 'string') {
+                    return rowItem.split(' | ');
+                }
+                if (Array.isArray(rowItem)) {
+                    return rowItem;
+                }
+                return [String(rowItem ?? '')];
+            });
+
+            return buildTableSection(
+                {
+                    table_name: `Tabela ${index + 1}`,
+                    header: headerValue,
+                    rows: normalizedRows
+                },
+                index
+            );
         }
 
         function buildObjectSection(objectValue, title) {
@@ -1408,7 +1450,13 @@
                     fragment.appendChild(buildTableSection(table, index));
                 });
             } else if (Array.isArray(parsed) && parsed.length) {
-                fragment.appendChild(buildArraySection(parsed, 'Itens'));
+                if (parsed.every((item) => item && typeof item === 'object' && 'header' in item && 'rows' in item)) {
+                    parsed.forEach((table, index) => {
+                        fragment.appendChild(buildWalletEntriesTableSection(table, index));
+                    });
+                } else {
+                    fragment.appendChild(buildArraySection(parsed, 'Itens'));
+                }
             } else if (parsed && typeof parsed === 'object') {
                 const objectFragment = buildObjectSection(parsed, parsed.table_name || 'Dados');
                 if (objectFragment.hasChildNodes()) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -300,6 +300,80 @@
             white-space: pre-wrap;
         }
 
+        .data-com-progress {
+            display: grid;
+            gap: 12px;
+            padding: 14px;
+            border-radius: 12px;
+            background: rgba(15, 23, 42, 0.45);
+            border: 1px solid rgba(148, 163, 184, 0.3);
+        }
+
+        .data-com-progress.hidden {
+            display: none;
+        }
+
+        .data-com-progress-header {
+            display: grid;
+            gap: 6px;
+        }
+
+        .data-com-progress-metadata {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            font-size: 13px;
+            color: var(--text-secondary);
+        }
+
+        .data-com-progress-metadata span {
+            background: rgba(250, 204, 21, 0.08);
+            border: 1px solid rgba(250, 204, 21, 0.2);
+            padding: 4px 10px;
+            border-radius: 999px;
+        }
+
+        .data-com-progress-tables {
+            display: grid;
+            gap: 12px;
+        }
+
+        .data-com-progress-table {
+            background: rgba(15, 23, 42, 0.6);
+            border-radius: 12px;
+            border: 1px solid rgba(148, 163, 184, 0.25);
+            padding: 12px;
+        }
+
+        .data-com-progress-table h3 {
+            margin: 0 0 10px;
+            font-size: 15px;
+            color: var(--accent);
+        }
+
+        .data-com-progress-table table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 13px;
+        }
+
+        .data-com-progress-table th,
+        .data-com-progress-table td {
+            padding: 8px 10px;
+            border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+            text-align: left;
+        }
+
+        .data-com-progress-table th {
+            color: var(--text-secondary);
+            font-weight: 600;
+        }
+
+        .data-com-empty {
+            font-size: 13px;
+            color: var(--text-secondary);
+        }
+
         .raw-wrapper {
             position: relative;
             margin-top: 16px;
@@ -710,6 +784,45 @@
                                 <input type="number" id="requestTimeout" min="5" step="5" value="1200">
                             </div>
                             <div id="resultContent" class="result-text"></div>
+                            <div id="dataComProgress" class="data-com-progress hidden">
+                                <div class="data-com-progress-header">
+                                    <h2 style="margin:0; font-size:16px;">Execução assíncrona do /data-com</h2>
+                                    <p class="desc" id="dataComProgressDescription">Aguardando início do processamento.</p>
+                                    <div class="data-com-progress-metadata">
+                                        <span id="dataComJobId">Job: -</span>
+                                        <span id="dataComProgressCounts">0/0 ativos</span>
+                                        <span id="dataComCurrentAsset">Ativo atual: -</span>
+                                    </div>
+                                </div>
+                                <div class="data-com-progress-tables">
+                                    <div class="data-com-progress-table">
+                                        <h3>Resultados já encontrados</h3>
+                                        <table>
+                                            <thead>
+                                                <tr>
+                                                    <th>Ativo</th>
+                                                    <th>Data-com</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody id="dataComResultsBody"></tbody>
+                                        </table>
+                                        <p id="dataComResultsEmpty" class="data-com-empty">Nenhum resultado confirmado ainda.</p>
+                                    </div>
+                                    <div class="data-com-progress-table">
+                                        <h3>Falhas registradas</h3>
+                                        <table>
+                                            <thead>
+                                                <tr>
+                                                    <th>Ativo</th>
+                                                    <th>Motivo</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody id="dataComFailuresBody"></tbody>
+                                        </table>
+                                        <p id="dataComFailuresEmpty" class="data-com-empty">Nenhuma falha registrada até o momento.</p>
+                                    </div>
+                                </div>
+                            </div>
                             <button type="button" id="toggleRaw" class="toggle-raw" hidden>Mostrar resposta completa</button>
                             <div id="rawWrapper" class="raw-wrapper hidden">
                                 <div class="raw-toolbar">
@@ -782,6 +895,15 @@
         const jsonModal = document.getElementById('jsonModal');
         const jsonModalBody = document.getElementById('jsonModalBody');
         const modalCloseButtons = document.querySelectorAll('[data-close-modal]');
+        const dataComProgress = document.getElementById('dataComProgress');
+        const dataComProgressDescription = document.getElementById('dataComProgressDescription');
+        const dataComJobIdLabel = document.getElementById('dataComJobId');
+        const dataComProgressCounts = document.getElementById('dataComProgressCounts');
+        const dataComCurrentAsset = document.getElementById('dataComCurrentAsset');
+        const dataComResultsBody = document.getElementById('dataComResultsBody');
+        const dataComFailuresBody = document.getElementById('dataComFailuresBody');
+        const dataComResultsEmpty = document.getElementById('dataComResultsEmpty');
+        const dataComFailuresEmpty = document.getElementById('dataComFailuresEmpty');
 
         const STORAGE_KEYS = {
             wallet: 'walletUrl',
@@ -802,6 +924,10 @@
         let autoAbortTimer = null;
         let abortReason = null;
         let copyFeedbackTimer = null;
+        let dataComPollingTimer = null;
+        let dataComLastStatus = null;
+        const dataComResultsIndex = new Map();
+        const dataComFailuresIndex = new Map();
 
         function persistInputs() {
             localStorage.setItem(STORAGE_KEYS.wallet, walletInput.value.trim());
@@ -870,6 +996,195 @@
 
             activityFeed.prepend(container);
             activityFeed.scrollTop = 0;
+        }
+
+        function resetDataComProgressSection() {
+            dataComResultsIndex.clear();
+            dataComFailuresIndex.clear();
+            if (dataComResultsBody) {
+                dataComResultsBody.innerHTML = '';
+            }
+            if (dataComFailuresBody) {
+                dataComFailuresBody.innerHTML = '';
+            }
+            if (dataComResultsEmpty) {
+                dataComResultsEmpty.hidden = false;
+            }
+            if (dataComFailuresEmpty) {
+                dataComFailuresEmpty.hidden = false;
+            }
+            if (dataComProgressDescription) {
+                dataComProgressDescription.textContent = 'Aguardando início do processamento.';
+            }
+            if (dataComProgressCounts) {
+                dataComProgressCounts.textContent = '0/0 ativos';
+            }
+            if (dataComCurrentAsset) {
+                dataComCurrentAsset.textContent = 'Ativo atual: -';
+            }
+            if (dataComJobIdLabel) {
+                dataComJobIdLabel.textContent = 'Job: -';
+            }
+            if (dataComProgress) {
+                dataComProgress.classList.add('hidden');
+            }
+        }
+
+        function showDataComProgressSection(jobId) {
+            if (dataComProgress) {
+                dataComProgress.classList.remove('hidden');
+            }
+            if (dataComJobIdLabel) {
+                dataComJobIdLabel.textContent = `Job: ${jobId}`;
+            }
+        }
+
+        function upsertDataComResultRow(asset, dateCom) {
+            if (!dataComResultsBody || !asset) {
+                return;
+            }
+            let row = dataComResultsIndex.get(asset);
+            if (!row) {
+                row = document.createElement('tr');
+                const assetCell = document.createElement('td');
+                assetCell.textContent = asset;
+                const dateCell = document.createElement('td');
+                dateCell.textContent = dateCom || '-';
+                row.appendChild(assetCell);
+                row.appendChild(dateCell);
+                dataComResultsBody.appendChild(row);
+                dataComResultsIndex.set(asset, row);
+            } else {
+                row.children[1].textContent = dateCom || '-';
+            }
+            if (dataComResultsEmpty) {
+                dataComResultsEmpty.hidden = dataComResultsIndex.size > 0;
+            }
+        }
+
+        function upsertDataComFailureRow(asset, reason) {
+            if (!dataComFailuresBody || !asset) {
+                return;
+            }
+            let row = dataComFailuresIndex.get(asset);
+            if (!row) {
+                row = document.createElement('tr');
+                const assetCell = document.createElement('td');
+                assetCell.textContent = asset;
+                const reasonCell = document.createElement('td');
+                reasonCell.textContent = reason || '-';
+                row.appendChild(assetCell);
+                row.appendChild(reasonCell);
+                dataComFailuresBody.appendChild(row);
+                dataComFailuresIndex.set(asset, row);
+            } else {
+                row.children[1].textContent = reason || '-';
+            }
+            if (dataComFailuresEmpty) {
+                dataComFailuresEmpty.hidden = dataComFailuresIndex.size > 0;
+            }
+        }
+
+        function updateDataComProgressUI(statusPayload) {
+            if (!statusPayload) {
+                return;
+            }
+            showDataComProgressSection(statusPayload.job_id || '-');
+            const processed = Number(statusPayload.processed_assets || 0);
+            const total = Number(statusPayload.total_assets || 0);
+            if (dataComProgressCounts) {
+                dataComProgressCounts.textContent = `${processed}/${total} ativos`;
+            }
+            if (dataComCurrentAsset) {
+                const currentAsset = statusPayload.current_asset || '-';
+                dataComCurrentAsset.textContent = `Ativo atual: ${currentAsset}`;
+            }
+            if (dataComProgressDescription) {
+                const message = statusPayload.last_message || 'Processamento em andamento.';
+                dataComProgressDescription.textContent = message;
+            }
+            if (Array.isArray(statusPayload.results)) {
+                statusPayload.results.forEach((resultItem) => {
+                    upsertDataComResultRow(resultItem.asset, resultItem.date_com);
+                });
+            }
+            if (Array.isArray(statusPayload.failures)) {
+                statusPayload.failures.forEach((failureItem) => {
+                    upsertDataComFailureRow(failureItem.asset, failureItem.reason);
+                });
+            }
+        }
+
+        function parseJsonSafely(text) {
+            try {
+                return JSON.parse(text);
+            } catch (error) {
+                return null;
+            }
+        }
+
+        function stopDataComPolling() {
+            if (dataComPollingTimer) {
+                clearInterval(dataComPollingTimer);
+                dataComPollingTimer = null;
+            }
+        }
+
+        function startDataComStatusPolling(jobId) {
+            stopDataComPolling();
+            resetDataComProgressSection();
+            showDataComProgressSection(jobId);
+            dataComLastStatus = null;
+
+            const pollStatus = async () => {
+                try {
+                    const response = await fetch(`/data-com/status?job_id=${encodeURIComponent(jobId)}`);
+                    const rawText = await response.text();
+                    const payload = parseJsonSafely(rawText);
+                    if (!payload) {
+                        return;
+                    }
+                    updateDataComProgressUI(payload);
+                    updateResult({
+                        status: payload.status === 'failed' ? 'error' : 'loading',
+                        description: payload.last_message || 'Processamento assíncrono em andamento.',
+                        content: '',
+                        raw: JSON.stringify(payload, null, 2)
+                    });
+
+                    if (payload.status !== dataComLastStatus) {
+                        dataComLastStatus = payload.status;
+                        addActivityEntry({
+                            title: `Status do job ${jobId}`,
+                            message: payload.last_message || `Status: ${payload.status}`,
+                            status: payload.status === 'failed' ? 'error' : 'info',
+                            raw: JSON.stringify(payload, null, 2)
+                        });
+                    }
+
+                    if (payload.status === 'completed' || payload.status === 'failed') {
+                        stopDataComPolling();
+                        updateResult({
+                            status: payload.status === 'completed' ? 'success' : 'error',
+                            description: payload.status === 'completed'
+                                ? 'Processamento assíncrono concluído.'
+                                : 'Processamento assíncrono falhou.',
+                            content: '',
+                            raw: JSON.stringify(payload, null, 2)
+                        });
+                    }
+                } catch (error) {
+                    stopDataComPolling();
+                    addActivityEntry({
+                        title: 'Erro ao consultar status',
+                        message: 'Não foi possível atualizar o status do job do /data-com.',
+                        status: 'error'
+                    });
+                }
+            };
+
+            pollStatus();
+            dataComPollingTimer = setInterval(pollStatus, 2500);
         }
 
         function updateResult({ status, description, content, raw }) {
@@ -1324,6 +1639,9 @@
             if (endpoint !== 'test') {
                 params.append('timeout_seconds', getConfiguredTimeout());
             }
+            if (endpoint === 'data-com') {
+                params.append('async', 'true');
+            }
             return params.toString();
         }
 
@@ -1381,6 +1699,11 @@
             const timeoutSeconds = getConfiguredTimeout();
             const timeoutMs = timeoutSeconds * 1000;
 
+            if (endpoint !== 'data-com') {
+                stopDataComPolling();
+                resetDataComProgressSection();
+            }
+
             setRequestState(true);
             activeController = new AbortController();
             abortReason = null;
@@ -1410,6 +1733,7 @@
                 const text = await response.text();
                 const interpretation = interpretResponseText(text, response);
                 const succeeded = response.ok;
+                const parsedResponse = parseJsonSafely(text);
 
                 updateResult({
                     status: succeeded ? 'success' : 'error',
@@ -1424,6 +1748,28 @@
                     status: succeeded ? 'success' : 'error',
                     raw: interpretation.raw
                 });
+
+                if (endpoint === 'data-com' && parsedResponse && parsedResponse.job_id) {
+                    resetDataComProgressSection();
+                    showDataComProgressSection(parsedResponse.job_id);
+                    addActivityEntry({
+                        title: 'Job iniciado para /data-com',
+                        message: `Job ${parsedResponse.job_id} criado. Aguardando o processamento em segundo plano.`,
+                        status: 'info',
+                        raw: interpretation.raw
+                    });
+                    updateResult({
+                        status: 'loading',
+                        description: 'Job criado. Estamos buscando os ativos em segundo plano.',
+                        content: 'Você pode acompanhar o progresso logo abaixo.',
+                        raw: interpretation.raw
+                    });
+                    startDataComStatusPolling(parsedResponse.job_id);
+                } else if (endpoint === 'data-com' && parsedResponse) {
+                    updateDataComProgressUI(parsedResponse);
+                } else {
+                    resetDataComProgressSection();
+                }
             } catch (error) {
                 if (error.name === 'AbortError') {
                     const wasTimeout = abortReason === 'timeout';
@@ -1525,6 +1871,7 @@
 
         setRequestState(false);
         hydrateInputs();
+        resetDataComProgressSection();
     </script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -670,6 +670,13 @@
                                 <input type="number" id="requestTimeout" min="5" step="5" value="1200">
                             </div>
                             <div id="resultContent" class="result-text"></div>
+                            <div id="assetsTablesPreview" class="data-com-progress hidden">
+                                <div class="data-com-progress-header">
+                                    <h2 style="margin:0; font-size:16px;">Tabelas retornadas pelo /assets</h2>
+                                    <p class="desc" id="assetsTablesDescription">As tabelas de ativos serão exibidas aqui.</p>
+                                </div>
+                                <div id="assetsTablesContainer" class="data-com-progress-tables"></div>
+                            </div>
                             <div id="dataComProgress" class="data-com-progress hidden">
                                 <div class="data-com-progress-header">
                                     <h2 style="margin:0; font-size:16px;">Execução assíncrona do /data-com</h2>
@@ -778,6 +785,9 @@
         const dataComFailuresBody = document.getElementById('dataComFailuresBody');
         const dataComResultsEmpty = document.getElementById('dataComResultsEmpty');
         const dataComFailuresEmpty = document.getElementById('dataComFailuresEmpty');
+        const assetsTablesPreview = document.getElementById('assetsTablesPreview');
+        const assetsTablesContainer = document.getElementById('assetsTablesContainer');
+        const assetsTablesDescription = document.getElementById('assetsTablesDescription');
 
         const STORAGE_KEYS = {
             wallet: 'walletUrl',
@@ -844,6 +854,18 @@
             }
             if (dataComProgress) {
                 dataComProgress.classList.add('hidden');
+            }
+        }
+
+        function resetAssetsTablesPreview() {
+            if (assetsTablesContainer) {
+                assetsTablesContainer.innerHTML = '';
+            }
+            if (assetsTablesDescription) {
+                assetsTablesDescription.textContent = 'As tabelas de ativos serão exibidas aqui.';
+            }
+            if (assetsTablesPreview) {
+                assetsTablesPreview.classList.add('hidden');
             }
         }
 
@@ -950,6 +972,27 @@
                     upsertDataComFailureRow(failureItem.asset, failureItem.reason);
                 });
             }
+        }
+
+        function updateAssetsTablesPreview(tables) {
+            if (!assetsTablesContainer || !assetsTablesPreview) {
+                return;
+            }
+            assetsTablesContainer.innerHTML = '';
+            if (!Array.isArray(tables) || !tables.length) {
+                if (assetsTablesDescription) {
+                    assetsTablesDescription.textContent = 'Nenhuma tabela foi encontrada na resposta do /assets.';
+                }
+                assetsTablesPreview.classList.remove('hidden');
+                return;
+            }
+            if (assetsTablesDescription) {
+                assetsTablesDescription.textContent = 'Tabelas de ativos carregadas.';
+            }
+            tables.forEach((tableItem, index) => {
+                assetsTablesContainer.appendChild(buildTableSection(tableItem, index));
+            });
+            assetsTablesPreview.classList.remove('hidden');
         }
 
         function openDataComResultsModal() {
@@ -1593,6 +1636,9 @@
                 stopDataComPolling();
                 resetDataComProgressSection();
             }
+            if (endpoint !== 'assets') {
+                resetAssetsTablesPreview();
+            }
 
             setRequestState(true);
             activeController = new AbortController();
@@ -1638,6 +1684,8 @@
                     startDataComStatusPolling(parsedResponse.job_id);
                 } else if (endpoint === 'data-com' && parsedResponse) {
                     updateDataComProgressUI(parsedResponse);
+                } else if (endpoint === 'assets' && parsedResponse && Array.isArray(parsedResponse.tables)) {
+                    updateAssetsTablesPreview(parsedResponse.tables);
                 } else {
                     resetDataComProgressSection();
                 }
@@ -1735,6 +1783,7 @@
         setRequestState(false);
         hydrateInputs();
         resetDataComProgressSection();
+        resetAssetsTablesPreview();
     </script>
 </body>
 </html>

--- a/wallet_entries.py
+++ b/wallet_entries.py
@@ -1,5 +1,11 @@
+from datetime import datetime, timezone
+
 from selenium.webdriver.common.by import By
 import time
+
+
+def _format_log_timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S %z")
 
 def extract_table_header(table):
     header_elem = table.find_element(By.TAG_NAME, "thead")
@@ -46,8 +52,8 @@ def extract_detailed_table_data(driver, table, paginate_id=None):
                     cells = row.find_elements(By.TAG_NAME, "td")
                     cell_texts = [cell.text.strip() for cell in cells]
                     detailed_rows.append(f"{order_type} | " + " | ".join(cell_texts))
-            except Exception as e:
-                print("Pagination error:", e)
+            except Exception as pagination_exception:
+                print(f"{_format_log_timestamp()} [wallet-entries] Pagination error: {pagination_exception}")
                 break
     return detailed_rows
 
@@ -59,9 +65,8 @@ def process_table(driver, table, index):
     elif index == 2:
         paginate_id = "crypto-entries_paginate"
     detailed_rows = extract_detailed_table_data(driver, table, paginate_id)
-    print(f"\nProcessing table {index}:")
-    print("Header:")
-    print(header)
+    print(f"{_format_log_timestamp()} [wallet-entries] Processing table {index}.")
+    print(f"{_format_log_timestamp()} [wallet-entries] Header: {header}")
     #print(f"Extracted {len(detailed_rows)} row(s) from table {index}.")
     for row in detailed_rows:
         print(row)
@@ -72,15 +77,15 @@ def process_table(driver, table, index):
     }
 
 def extract_wallet_entries(driver, url):
-    print("Accessing wallet entries...")
+    print(f"{_format_log_timestamp()} [wallet-entries] Accessing wallet entries...")
     driver.get(url)
     time.sleep(10)
     tables = driver.find_elements(By.CSS_SELECTOR, "table")
     if len(tables) < 4:
-        print("Insufficient tables found on the page.")
+        print(f"{_format_log_timestamp()} [wallet-entries] Insufficient tables found on the page.")
         return []
     tables = tables[:4]
-    print(f"{len(tables)} table(s) found (adjusted to 4).")
+    print(f"{_format_log_timestamp()} [wallet-entries] {len(tables)} table(s) found (adjusted to 4).")
     results = []
     for i, table in enumerate(tables, start=1):
         result = process_table(driver, table, i)


### PR DESCRIPTION
### Motivation
- Prevent a single failing asset (e.g. timeouts for `BTLG11`) from aborting the entire `/data-com` route.
- Give visibility into which assets failed and why while still returning successful results. 
- Centralize per-asset processing and error handling to respect time budget constraints. 

### Description
- Added a failures collection and changed the response shape to return `results` and `failures` JSON fields instead of a plain list. 
- Introduced helper ` _resolve_latest_dividend_date_for_asset` to encapsulate per-asset URL resolution, HTTP extraction, Selenium fallback, and failure reason reporting. 
- Updated `fetch_latest_data_com` to call the helper per asset, continue processing on errors, and accumulate failure reasons for each asset. 
- Ensured the Selenium driver is reused across assets and always quit when finished, and preserved existing `ProcessingTimeoutError` handling. 

### Testing
- No automated tests were executed as requested. 
- Manual validation should confirm that `/data-com` now returns successful asset dates under `results` and per-asset failure records under `failures`. 
- Timeouts and `ProcessingTimeoutError` cases are returned as failure reasons per asset.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69485c1aec34832c8afc6d9bd9d87585)